### PR TITLE
Drop dead Travis badge from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 [![Build Status](https://github.com/openelections/openelections-data-wi/actions/workflows/data_tests.yml/badge.svg?branch=master)](https://github.com/openelections/openelections-data-wi/actions/workflows/data_tests.yml?query=branch%3Amaster)
-[![Build Status](https://travis-ci.org/davipo/openelections-data-wi.svg?branch=master)](https://travis-ci.org/davipo/openelections-data-wi)
 
 # openelections-data-wi
 Pre-processed election results for Wisconsin elections


### PR DESCRIPTION
The second badge in the README pointed at travis-ci.org (the .org domain shut down a while back) for a personal fork (davipo/openelections-data-wi) last pushed in 2021. The first badge already covers the real build status via GitHub Actions, so this just drops the broken one.